### PR TITLE
api version 5

### DIFF
--- a/src/Octoshift/Services/AdoApi.cs
+++ b/src/Octoshift/Services/AdoApi.cs
@@ -61,7 +61,7 @@ public class AdoApi
 
     public virtual async Task<DateTime> GetLastPushDate(string org, string teamProject, string repo)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repo.EscapeDataString()}/pushes?$top=1&api-version=7.1-preview.2";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repo.EscapeDataString()}/pushes?$top=1&api-version=5.0-preview.1";
         var response = await _client.GetAsync(url);
 
         var data = JObject.Parse(response);
@@ -72,13 +72,13 @@ public class AdoApi
 
     public virtual async Task<int> GetCommitCountSince(string org, string teamProject, string repo, DateTime fromDate)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repo.EscapeDataString()}/commits?searchCriteria.fromDate={fromDate.ToString("d", CultureInfo.InvariantCulture)}&api-version=7.1-preview.1";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repo.EscapeDataString()}/commits?searchCriteria.fromDate={fromDate.ToString("d", CultureInfo.InvariantCulture)}&api-version=5.0-preview.1";
         return await _client.GetCountUsingSkip(url);
     }
 
     public virtual async Task<IEnumerable<string>> GetPushersSince(string org, string teamProject, string repo, DateTime fromDate)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repo.EscapeDataString()}/pushes?searchCriteria.fromDate={fromDate.ToString("d", CultureInfo.InvariantCulture)}&api-version=7.1-preview.1";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repo.EscapeDataString()}/pushes?searchCriteria.fromDate={fromDate.ToString("d", CultureInfo.InvariantCulture)}&api-version=5.0-preview.1";
         var response = await _client.GetWithPagingTopSkipAsync(url, x => $"{x["pushedBy"]["displayName"]} ({x["pushedBy"]["uniqueName"]})");
 
         return response;
@@ -86,7 +86,7 @@ public class AdoApi
 
     public virtual async Task<int> GetPullRequestCount(string org, string teamProject, string repo)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repo.EscapeDataString()}/pullrequests?searchCriteria.status=all&api-version=7.1-preview.1";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repo.EscapeDataString()}/pullrequests?searchCriteria.status=all&api-version=5.0-preview.1";
         var count = await _client.GetCountUsingSkip(url);
         return count;
     }
@@ -134,7 +134,7 @@ public class AdoApi
 
     public virtual async Task<IEnumerable<string>> GetTeamProjects(string org)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/_apis/projects?api-version=6.1-preview";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/_apis/projects?api-version=5.0-preview.1";
         var data = await _client.GetWithPagingAsync(url);
         return data.Select(x => (string)x["name"]).ToList();
     }
@@ -143,7 +143,7 @@ public class AdoApi
 
     public virtual async Task<IEnumerable<AdoRepository>> GetRepos(string org, string teamProject)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories?api-version=6.1-preview.1";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories?api-version=5.0-preview.1";
         var data = await _client.GetWithPagingAsync(url);
         return data
             .Select(x => new AdoRepository
@@ -177,7 +177,7 @@ public class AdoApi
 
     private async Task<string> GetTeamProjectGithubAppId(string org, string githubOrg, string teamProject)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=5.0-preview.1";
         var response = await _client.GetWithPagingAsync(url);
 
         var endpoint = response.FirstOrDefault(x => ((string)x["type"]).Equals("GitHub", StringComparison.OrdinalIgnoreCase) && ((string)x["name"]).Equals(githubOrg, StringComparison.OrdinalIgnoreCase));
@@ -472,7 +472,7 @@ public class AdoApi
 
     public virtual async Task<bool> ContainsServiceConnection(string adoOrg, string adoTeamProject, string serviceConnectionId)
     {
-        var url = $"{_adoBaseUrl}/{adoOrg.EscapeDataString()}/{adoTeamProject.EscapeDataString()}/_apis/serviceendpoint/endpoints/{serviceConnectionId.EscapeDataString()}?api-version=6.0-preview.4";
+        var url = $"{_adoBaseUrl}/{adoOrg.EscapeDataString()}/{adoTeamProject.EscapeDataString()}/_apis/serviceendpoint/endpoints/{serviceConnectionId.EscapeDataString()}?api-version=5.0-preview.1";
 
         var response = await _client.GetAsync(url);
 
@@ -482,7 +482,7 @@ public class AdoApi
 
     public virtual async Task ShareServiceConnection(string adoOrg, string adoTeamProject, string adoTeamProjectId, string serviceConnectionId)
     {
-        var url = $"{_adoBaseUrl}/{adoOrg.EscapeDataString()}/_apis/serviceendpoint/endpoints/{serviceConnectionId.EscapeDataString()}?api-version=6.0-preview.4";
+        var url = $"{_adoBaseUrl}/{adoOrg.EscapeDataString()}/_apis/serviceendpoint/endpoints/{serviceConnectionId.EscapeDataString()}?api-version=5.0-preview.1";
 
         var payload = new[]
         {
@@ -502,7 +502,7 @@ public class AdoApi
 
     public virtual async Task<(string DefaultBranch, string Clean, string CheckoutSubmodules)> GetPipeline(string org, string teamProject, int pipelineId)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/build/definitions/{pipelineId}?api-version=6.0";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/build/definitions/{pipelineId}?api-version=5.0-preview.1";
 
         var response = await _client.GetAsync(url);
         var data = JObject.Parse(response);
@@ -525,7 +525,7 @@ public class AdoApi
 
     public virtual async Task ChangePipelineRepo(string adoOrg, string teamProject, int pipelineId, string defaultBranch, string clean, string checkoutSubmodules, string githubOrg, string githubRepo, string connectedServiceId)
     {
-        var url = $"{_adoBaseUrl}/{adoOrg.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/build/definitions/{pipelineId}?api-version=6.0";
+        var url = $"{_adoBaseUrl}/{adoOrg.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/build/definitions/{pipelineId}?api-version=5.0-preview.1";
 
         var response = await _client.GetAsync(url);
         var data = JObject.Parse(response);
@@ -646,7 +646,7 @@ public class AdoApi
 
     public virtual async Task DisableRepo(string org, string teamProject, string repoId)
     {
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repoId.EscapeDataString()}?api-version=6.1-preview.1";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/{teamProject.EscapeDataString()}/_apis/git/repositories/{repoId.EscapeDataString()}?api-version=5.0-preview.1";
 
         var payload = new { isDisabled = true };
         await _client.PatchAsync(url, payload);
@@ -654,7 +654,7 @@ public class AdoApi
 
     public virtual async Task<string> GetIdentityDescriptor(string org, string teamProjectId, string groupName)
     {
-        var url = $"https://vssps.dev.azure.com/{org.EscapeDataString()}/_apis/identities?searchFilter=General&filterValue={groupName.EscapeDataString()}&queryMembership=None&api-version=6.1-preview.1";
+        var url = $"https://vssps.dev.azure.com/{org.EscapeDataString()}/_apis/identities?searchFilter=General&filterValue={groupName.EscapeDataString()}&queryMembership=None&api-version=5.0-preview.1";
 
         var identities = await _client.GetWithPagingAsync(url);
 
@@ -666,7 +666,7 @@ public class AdoApi
     {
         var gitReposNamespace = "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87";
 
-        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/_apis/accesscontrolentries/{gitReposNamespace.EscapeDataString()}?api-version=6.1-preview.1";
+        var url = $"{_adoBaseUrl}/{org.EscapeDataString()}/_apis/accesscontrolentries/{gitReposNamespace.EscapeDataString()}?api-version=5.0-preview.1";
 
         var payload = new
         {
@@ -702,7 +702,7 @@ public class AdoApi
 
     private async Task<bool> HasPermission(string org, string securityNamespaceId, int permission)
     {
-        var response = await _client.GetAsync($"{_adoBaseUrl}/{org.EscapeDataString()}/_apis/permissions/{securityNamespaceId.EscapeDataString()}/{permission}?api-version=6.0");
+        var response = await _client.GetAsync($"{_adoBaseUrl}/{org.EscapeDataString()}/_apis/permissions/{securityNamespaceId.EscapeDataString()}/{permission}?api-version=5.0-preview.1");
         return ((string)JObject.Parse(response)["value"]?.FirstOrDefault()).ToBool();
     }
 }

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -242,7 +242,7 @@ namespace OctoshiftCLI.IntegrationTests
 
         private async Task<string> CreatePipeline(string org, string teamProject, string name, string ymlFile, string repoId, string repoName, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/{teamProject}/_apis/pipelines?api-version=6.1-preview.1";
+            var url = $"{adoServerUrl}/{org}/{teamProject}/_apis/pipelines?api-version=5.0-preview.1";
 
             var payload = new
             {
@@ -268,7 +268,7 @@ namespace OctoshiftCLI.IntegrationTests
 
         private async Task<string> InitializeRepo(string org, string repoId, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/_apis/git/repositories/{repoId}/pushes?api-version=6.0";
+            var url = $"{adoServerUrl}/{org}/_apis/git/repositories/{repoId}/pushes?api-version=5.0-preview.1";
 
             var payload = new
             {
@@ -311,7 +311,7 @@ namespace OctoshiftCLI.IntegrationTests
 
         private async Task<string> PushDummyPipelineYaml(string org, string repoId, string parentCommit, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/_apis/git/repositories/{repoId}/pushes?api-version=6.0";
+            var url = $"{adoServerUrl}/{org}/_apis/git/repositories/{repoId}/pushes?api-version=5.0-preview.1";
 
             var payload = new
             {
@@ -370,7 +370,7 @@ steps:
             var gitReposNamespace = "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87";
             var token = $"repoV2/{teamProjectId}/{repoId}";
 
-            var url = $"{adoServerUrl}/{org}/_apis/accesscontrollists/{gitReposNamespace}?token={token}&descriptors={identityDescriptor}&api-version=6.0";
+            var url = $"{adoServerUrl}/{org}/_apis/accesscontrollists/{gitReposNamespace}?token={token}&descriptors={identityDescriptor}&api-version=5.0-preview.1";
 
             var response = await _adoClient.GetAsync(url);
 
@@ -382,14 +382,14 @@ steps:
 
         private async Task<IEnumerable<(string Id, string Name, string Type)>> GetServiceConnections(string org, string teamProject, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/{teamProject}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4";
+            var url = $"{adoServerUrl}/{org}/{teamProject}/_apis/serviceendpoint/endpoints?api-version=5.0-preview.1";
             var response = await _adoClient.GetWithPagingAsync(url);
             return response.Select(x => ((string)x["id"], (string)x["name"], (string)x["type"]));
         }
 
         private async Task<(string Id, string Type, string ConnectedServiceId)> GetPipelineRepo(string org, string teamProject, int pipelineId, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/{teamProject}/_apis/build/definitions/{pipelineId}?api-version=6.0";
+            var url = $"{adoServerUrl}/{org}/{teamProject}/_apis/build/definitions/{pipelineId}?api-version=5.0-preview.1";
             var response = await _adoClient.GetAsync(url);
             var result = JObject.Parse(response)["repository"];
             return ((string)result["id"], (string)result["type"], (string)result["properties"]["connectedServiceId"]);
@@ -397,7 +397,7 @@ steps:
 
         private async Task<string> DeleteTeamProject(string org, string teamProjectId, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/_apis/projects/{teamProjectId}?api-version=6.0";
+            var url = $"{adoServerUrl}/{org}/_apis/projects/{teamProjectId}?api-version=5.0-preview.1";
 
             var response = await _adoClient.DeleteAsync(url);
             var result = JObject.Parse(response);
@@ -407,7 +407,7 @@ steps:
 
         private async Task<string> QueueCreateTeamProject(string org, string teamProject, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/_apis/projects?api-version=6.0";
+            var url = $"{adoServerUrl}/{org}/_apis/projects?api-version=5.0-preview.1";
 
             var payload = new
             {
@@ -433,14 +433,14 @@ steps:
 
         private async Task<string> GetTeamProjectStatus(string org, string teamProjectId, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/_apis/projects/{teamProjectId}?api-version=6.0";
+            var url = $"{adoServerUrl}/{org}/_apis/projects/{teamProjectId}?api-version=5.0-preview.1";
             var response = await _adoClient.GetAsync(url);
             return (string)JObject.Parse(response)["state"];
         }
 
         private async Task<string> GetOperationStatus(string org, string operationId, string adoServerUrl)
         {
-            var url = $"{adoServerUrl}/{org}/_apis/operations/{operationId}?api-version=6.0";
+            var url = $"{adoServerUrl}/{org}/_apis/operations/{operationId}?api-version=5.0-preview.1";
             var response = await _adoClient.GetAsync(url);
             return (string)JObject.Parse(response)["status"];
         }

--- a/src/OctoshiftCLI.Tests/Octoshift/Services/AdoApiTests.cs
+++ b/src/OctoshiftCLI.Tests/Octoshift/Services/AdoApiTests.cs
@@ -135,7 +135,7 @@ public class AdoApiTests
     public async Task GetTeamProjects_Should_Return_All_Team_Projects()
     {
         var teamProject2 = "foo-tp2";
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/projects?api-version=6.1-preview";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/projects?api-version=5.0-preview.1";
         var json = new object[]
         {
             new
@@ -162,7 +162,7 @@ public class AdoApiTests
     [Fact]
     public async Task GetEnabledRepos_Should_Not_Return_Disabled_Repos()
     {
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories?api-version=6.1-preview.1";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories?api-version=5.0-preview.1";
         var repo1 = new AdoRepository { Id = "1", Name = ADO_REPO, Size = 123, IsDisabled = false };
         var repo2 = new AdoRepository { Id = "2", Name = "foo-repo2", Size = 5678, IsDisabled = false };
         var json = new object[]
@@ -216,8 +216,8 @@ public class AdoApiTests
         };
         var response = JArray.Parse(json.ToJson());
 
-        _mockAdoClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4").Result).Returns(JArray.Parse("[]"));
-        _mockAdoClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{teamProject2.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4").Result).Returns(response);
+        _mockAdoClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=5.0-preview.1").Result).Returns(JArray.Parse("[]"));
+        _mockAdoClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{teamProject2.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=5.0-preview.1").Result).Returns(response);
 
         var result = await sut.GetGithubAppId(ADO_ORG, GITHUB_ORG, teamProjects);
 
@@ -242,8 +242,8 @@ public class AdoApiTests
         };
         var response = JArray.Parse(json.ToJson());
 
-        _mockAdoClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4").Result).Returns(JArray.Parse("[]"));
-        _mockAdoClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{teamProject2.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=6.0-preview.4").Result).Returns(response);
+        _mockAdoClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=5.0-preview.1").Result).Returns(JArray.Parse("[]"));
+        _mockAdoClient.Setup(x => x.GetWithPagingAsync($"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{teamProject2.EscapeDataString()}/_apis/serviceendpoint/endpoints?api-version=5.0-preview.1").Result).Returns(response);
 
         var result = await sut.GetGithubAppId(ADO_ORG, GITHUB_ORG, teamProjects);
 
@@ -531,7 +531,7 @@ public class AdoApiTests
     [Fact]
     public async Task GetPullRequestCount_Should_Return_Count()
     {
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pullrequests?searchCriteria.status=all&api-version=7.1-preview.1";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pullrequests?searchCriteria.status=all&api-version=5.0-preview.1";
         var expectedCount = 12;
 
         _mockAdoClient.Setup(x => x.GetCountUsingSkip(endpoint)).ReturnsAsync(expectedCount);
@@ -544,7 +544,7 @@ public class AdoApiTests
     [Fact]
     public async Task GetLastPushDate_Should_Return_LastPushDate()
     {
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?$top=1&api-version=7.1-preview.2";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?$top=1&api-version=5.0-preview.1";
         var expectedDate = new DateTime(2022, 2, 14);
 
         var response = new
@@ -565,7 +565,7 @@ public class AdoApiTests
     [Fact]
     public async Task GetLastPushDate_Should_Return_MinDate_When_No_Pushes()
     {
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?$top=1&api-version=7.1-preview.2";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?$top=1&api-version=5.0-preview.1";
 
         var response = "{ count: 0, value: [] }";
 
@@ -579,7 +579,7 @@ public class AdoApiTests
     [Fact]
     public async Task GetLastPushDate_Should_Be_Locale_Independent()
     {
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?$top=1&api-version=7.1-preview.2";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?$top=1&api-version=5.0-preview.1";
         var expectedDate = new DateTime(2016, 4, 22);
 
         var response = new
@@ -604,7 +604,7 @@ public class AdoApiTests
     {
         var fromDate = new DateTime(2022, 2, 14);
         var fromDateIso = "02/14/2022";
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/commits?searchCriteria.fromDate={fromDateIso}&api-version=7.1-preview.1";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/commits?searchCriteria.fromDate={fromDateIso}&api-version=5.0-preview.1";
         var expectedCount = 12;
 
         _mockAdoClient.Setup(x => x.GetCountUsingSkip(endpoint)).ReturnsAsync(expectedCount);
@@ -619,7 +619,7 @@ public class AdoApiTests
     {
         var fromDate = new DateTime(2022, 2, 14);
         var fromDateIso = "02/14/2022";
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/commits?searchCriteria.fromDate={fromDateIso}&api-version=7.1-preview.1";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/commits?searchCriteria.fromDate={fromDateIso}&api-version=5.0-preview.1";
         var expectedCount = 12;
 
         _mockAdoClient.Setup(x => x.GetCountUsingSkip(endpoint)).ReturnsAsync(expectedCount);
@@ -636,7 +636,7 @@ public class AdoApiTests
     {
         var fromDate = new DateTime(2022, 2, 14);
         var fromDateIso = "02/14/2022";
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?searchCriteria.fromDate={fromDateIso}&api-version=7.1-preview.1";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?searchCriteria.fromDate={fromDateIso}&api-version=5.0-preview.1";
         var pusher1DisplayName = "Dylan";
         var pusher1UniqueName = "dsmith";
         var pusher2DisplayName = "Tom";
@@ -670,7 +670,7 @@ public class AdoApiTests
     {
         var fromDate = new DateTime(2022, 2, 14);
         var fromDateIso = "02/14/2022";
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?searchCriteria.fromDate={fromDateIso}&api-version=7.1-preview.1";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{ADO_REPO.EscapeDataString()}/pushes?searchCriteria.fromDate={fromDateIso}&api-version=5.0-preview.1";
         var pusher1DisplayName = "Dylan";
         var pusher1UniqueName = "dsmith";
         var pusher2DisplayName = "Tom";
@@ -888,7 +888,7 @@ public class AdoApiTests
     {
         var serviceConnectionId = Guid.NewGuid().ToString();
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/serviceendpoint/endpoints/{serviceConnectionId}?api-version=6.0-preview.4";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/serviceendpoint/endpoints/{serviceConnectionId}?api-version=5.0-preview.1";
 
         _mockAdoClient.Setup(x => x.GetAsync(endpoint).Result).Returns("null");
 
@@ -903,7 +903,7 @@ public class AdoApiTests
     {
         var serviceConnectionId = Guid.NewGuid().ToString();
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/serviceendpoint/endpoints/{serviceConnectionId}?api-version=6.0-preview.4";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/serviceendpoint/endpoints/{serviceConnectionId}?api-version=5.0-preview.1";
 
         var payload = new[]
         {
@@ -931,7 +931,7 @@ public class AdoApiTests
         var defaultBranch = $"refs/heads/{branchName}";
         var clean = "True";
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions/{pipelineId}?api-version=6.0";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions/{pipelineId}?api-version=5.0-preview.1";
         var response = new
         {
             repository = new
@@ -977,7 +977,7 @@ public class AdoApiTests
             oneLastThing = false
         };
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions/{pipelineId}?api-version=6.0";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/build/definitions/{pipelineId}?api-version=5.0-preview.1";
 
         var newJson = new
         {
@@ -1151,7 +1151,7 @@ public class AdoApiTests
     {
         var repoId = Guid.NewGuid().ToString();
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{repoId}?api-version=6.1-preview.1";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/{ADO_TEAM_PROJECT.EscapeDataString()}/_apis/git/repositories/{repoId}?api-version=5.0-preview.1";
 
         await sut.DisableRepo(ADO_ORG, ADO_TEAM_PROJECT, repoId);
 
@@ -1166,7 +1166,7 @@ public class AdoApiTests
         var groupName = "foo-group";
         var identityDescriptor = "foo-id";
 
-        var endpoint = $"https://vssps.dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/identities?searchFilter=General&filterValue={groupName}&queryMembership=None&api-version=6.1-preview.1";
+        var endpoint = $"https://vssps.dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/identities?searchFilter=General&filterValue={groupName}&queryMembership=None&api-version=5.0-preview.1";
         var response = $@"[{{ properties: {{ LocalScopeId: {{ $value: ""wrong"" }} }}, descriptor: ""blah"" }}, {{ descriptor: ""{identityDescriptor}"", properties: {{ LocalScopeId: {{ $value: ""{ADO_TEAM_PROJECT_ID}"" }} }} }}]";
 
         _mockAdoClient.Setup(x => x.GetWithPagingAsync(endpoint).Result).Returns(JArray.Parse(response));
@@ -1183,7 +1183,7 @@ public class AdoApiTests
         var identityDescriptor = "foo-id";
         var gitReposNamespace = "2e9eb7ed-3c0a-47d4-87c1-0ffdd275fd87";
 
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/accesscontrolentries/{gitReposNamespace}?api-version=6.1-preview.1";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/accesscontrolentries/{gitReposNamespace}?api-version=5.0-preview.1";
 
         var payload = new
         {
@@ -1216,7 +1216,7 @@ public class AdoApiTests
     public async Task IsCallerOrgAdmin_Returns_True_When_Caller_Is_Org_Admin()
     {
         // Arrange
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=6.0";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=5.0-preview.1";
         const string responseJson = "{\"count\":1,\"value\":[true]}";
 
         _mockAdoClient.Setup(m => m.GetAsync(endpoint)).ReturnsAsync(responseJson);
@@ -1232,7 +1232,7 @@ public class AdoApiTests
     public async Task IsCallerOrgAdmin_Returns_False_When_Caller_Is_Not_Org_Admin()
     {
         // Arrange
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=6.0";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=5.0-preview.1";
         const string responseJson = "{\"count\":1,\"value\":[false]}";
 
         _mockAdoClient.Setup(m => m.GetAsync(endpoint)).ReturnsAsync(responseJson);
@@ -1248,7 +1248,7 @@ public class AdoApiTests
     public async Task IsCallerOrgAdmin_Returns_First_Value_From_Value_Array()
     {
         // Arrange
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=6.0";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=5.0-preview.1";
         const string responseJson = "{\"count\":3,\"value\":[true, false, false]}";
 
         _mockAdoClient.Setup(m => m.GetAsync(endpoint)).ReturnsAsync(responseJson);
@@ -1264,7 +1264,7 @@ public class AdoApiTests
     public async Task IsCallerOrgAdmin_Returns_False_When_Response_Payload_Has_Empty_Value_Array()
     {
         // Arrange
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=6.0";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=5.0-preview.1";
         const string responseJson = "{\"count\":0,\"value\":[]}";
 
         _mockAdoClient.Setup(m => m.GetAsync(endpoint)).ReturnsAsync(responseJson);
@@ -1280,7 +1280,7 @@ public class AdoApiTests
     public async Task IsCallerOrgAdmin_Returns_False_When_Response_Payload_Has_No_Value()
     {
         // Arrange
-        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=6.0";
+        var endpoint = $"https://dev.azure.com/{ADO_ORG.EscapeDataString()}/_apis/permissions/3e65f728-f8bc-4ecd-8764-7e378b19bfa7/2?api-version=5.0-preview.1";
         const string responseJson = "{}";
 
         _mockAdoClient.Setup(m => m.GetAsync(endpoint)).ReturnsAsync(responseJson);


### PR DESCRIPTION
This pull request updates the API version used in various methods across multiple files in the `Octoshift` project. The changes consistently downgrade the API version from `6.0` or `7.1` to `5.0-preview.1`.

The most important changes include:

*API Version Downgrade in `AdoApi.cs`*:

* Updated the API version to `5.0-preview.1` in methods such as `GetLastPushDate`, `GetCommitCountSince`, `GetPushersSince`, `GetPullRequestCount`, `GetTeamProjects`, `GetRepos`, `GetGithubAppId`, `ContainsServiceConnection`, `ShareServiceConnection`, `GetPipeline`, `ChangePipelineRepo`, `DisableRepo`, `GetIdentityDescriptor`, `LockRepo`, and `HasPermission`. [[1]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL64-R64) [[2]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL75-R89) [[3]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL137-R137) [[4]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL146-R146) [[5]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL180-R180) [[6]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL475-R475) [[7]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL485-R485) [[8]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL505-R505) [[9]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL528-R528) [[10]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL649-R657) [[11]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL669-R669) [[12]](diffhunk://#diff-038c3a8177c11c96fab0dd47300b65152579e8a935142c80e5e15c17844fbebfL705-R705)

*API Version Downgrade in `TestHelper.cs`*:

* Updated the API version to `5.0-preview.1` in methods such as `CreatePipeline`, `InitializeRepo`, `PushDummyPipelineYaml`, `GetServiceConnections`, `GetPipelineRepo`, `DeleteTeamProject`, `QueueCreateTeamProject`, `GetTeamProjectStatus`, and `GetOperationStatus`. [[1]](diffhunk://#diff-3b0c79cedbeb13436f2ffef35d323ed637852fde684e08731fc57178033c37b1L245-R245) [[2]](diffhunk://#diff-3b0c79cedbeb13436f2ffef35d323ed637852fde684e08731fc57178033c37b1L271-R271) [[3]](diffhunk://#diff-3b0c79cedbeb13436f2ffef35d323ed637852fde684e08731fc57178033c37b1L314-R314) [[4]](diffhunk://#diff-3b0c79cedbeb13436f2ffef35d323ed637852fde684e08731fc57178033c37b1L373-R373) [[5]](diffhunk://#diff-3b0c79cedbeb13436f2ffef35d323ed637852fde684e08731fc57178033c37b1L385-R400) [[6]](diffhunk://#diff-3b0c79cedbeb13436f2ffef35d323ed637852fde684e08731fc57178033c37b1L410-R410) [[7]](diffhunk://#diff-3b0c79cedbeb13436f2ffef35d323ed637852fde684e08731fc57178033c37b1L436-R443)

*API Version Downgrade in `AdoApiTests.cs`*:

* Updated the API version to `5.0-preview.1` in test methods such as `GetTeamProjects_Should_Return_All_Team_Projects`, `GetEnabledRepos_Should_Not_Return_Disabled_Repos`, and `GetGithubAppId_Should_Skip_Team_Projects_With_No_Endpoints`. [[1]](diffhunk://#diff-4b4f40fe1aa96987ac470f8135b20b41ca8564a5012738c3262b46861713b3cdL138-R138) [[2]](diffhunk://#diff-4b4f40fe1aa96987ac470f8135b20b41ca8564a5012738c3262b46861713b3cdL165-R165) [[3]](diffhunk://#diff-4b4f40fe1aa96987ac470f8135b20b41ca8564a5012738c3262b46861713b3cdL219-R220)